### PR TITLE
Add try-except around hashlib.md5 calls passing usedforsecurity=False

### DIFF
--- a/boto/mws/connection.py
+++ b/boto/mws/connection.py
@@ -54,7 +54,18 @@ api_version_path = {
     'OffAmazonPayments': ('2013-01-01', 'SellerId',
                           '/OffAmazonPayments/2013-01-01'),
 }
-content_md5 = lambda c: encodebytes(hashlib.md5(c, usedforsecurity=False).digest()).strip()
+
+# Current stable version of python does not have FIPS support for hashlib. Passing
+# usedforsecurity=False only works in RHEL versions of python, and is needed to
+# run this code on hardened RHEL machines. The try-except block will not be needed once
+# the following issue is resolved:
+#
+# https://bugs.python.org/issue9216
+try:
+    content_md5 = lambda c: encodebytes(hashlib.md5(c, usedforsecurity=False).digest()).strip()
+except TypeError:
+    content_md5 = lambda c: encodebytes(hashlib.md5(c).digest()).strip()
+
 decorated_attrs = ('action', 'response', 'section',
                    'quota', 'restore', 'version')
 api_call_map = {}

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -1006,7 +1006,17 @@ def compute_md5(fp, buf_size=8192, size=None):
 
 def compute_hash(fp, buf_size=8192, size=None, hash_algorithm=md5):
     if hash_algorithm == md5:
-        hash_obj = hash_algorithm(usedforsecurity=False)
+
+        # Current stable version of python does not have FIPS support for hashlib. Passing
+        # usedforsecurity=False only works in RHEL versions of python, and is needed to
+        # run this code on hardened RHEL machines. The try-except block will not be needed once
+        # the following issue is resolved:
+        #
+        # https://bugs.python.org/issue9216
+        try:
+            hash_obj = hash_algorithm(usedforsecurity=False)
+        except TypeError:
+            hash_obj = hash_algorithm()
     else:
         hash_obj = hash_algorithm()
     spos = fp.tell()

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def readme():
         return f.read()
 
 setup(name = "boto",
-      version = "{0}+nimbis.2".format(__version__),
+      version = "{0}+nimbis.3".format(__version__),
       description = "Amazon Web Services Library",
       long_description = readme(),
       author = "Mitch Garnaat",

--- a/tests/db/test_password.py
+++ b/tests/db/test_password.py
@@ -74,7 +74,18 @@ class PasswordPropertyTest(unittest.TestCase):
 
         obj = MyModel()
         obj.password = 'bar'
-        expected = myhashfunc('bar', usedforsecurity=False).hexdigest() #hmac.new('mysecret','bar').hexdigest()
+
+        # Current stable version of python does not have FIPS support for hashlib. Passing
+        # usedforsecurity=False only works in RHEL versions of python, and is needed to
+        # run this code on hardened RHEL machines. The try-except block will not be needed once
+        # the following issue is resolved:
+        #
+        # https://bugs.python.org/issue9216
+        try:
+            expected = myhashfunc('bar', usedforsecurity=False).hexdigest() #hmac.new('mysecret','bar').hexdigest()
+        except TypeError:
+            expected = myhashfunc('bar').hexdigest() #hmac.new('mysecret','bar').hexdigest()
+
         log.debug("\npassword=%s\nexpected=%s" % (obj.password, expected))
         self.assertTrue(obj.password == 'bar' )
         obj.save()


### PR DESCRIPTION
An exception is currently thrown if passing the usedforsecurity=False
flag when calling hashlib.md5 using a version of python that currently
does not support FIPS.

At the time of this commit, the RHEL version of python supported
this, however, other versions did not. This issue is captured here:
https://bugs.python.org/issue9216

These changes can be dropped once that issue is resolved.